### PR TITLE
Enable photo format selection in RSS enclosure element

### DIFF
--- a/ella/core/conf.py
+++ b/ella/core/conf.py
@@ -22,6 +22,7 @@ VERSION = 1
 SERVER_INFO = {}
 
 RSS_NUM_IN_FEED = 10
+RSS_ENCLOSURE_PHOTO_FORMAT = None
 
 # middlewares
 ECACHE_INFO = 'ella.core.middleware.ECACHE_INFO'

--- a/ella/core/feeds.py
+++ b/ella/core/feeds.py
@@ -8,6 +8,7 @@ from ella.core.models import Listing, Category
 from ella.core.views import get_content_type
 from ella.core.cache.utils import get_cached_object, get_cached_object_or_404
 from ella.core.conf import core_settings
+from ella.photos.models import Format
 
 class RSSTopCategoryListings(Feed):
     def get_object(self, bits):
@@ -77,13 +78,15 @@ class RSSTopCategoryListings(Feed):
     def item_pubdate(self, item):
         return item.publish_from
     
-    def get_enclosure_image(self, item):
+    def get_enclosure_image(self, item, enc_format=core_settings.RSS_ENCLOSURE_PHOTO_FORMAT):
         if getattr(item.target, 'photo'):
-            enc_format = core_settings.RSS_ENCLOSURE_PHOTO_FORMAT 
             if enc_format is not None:
-                formated_photo = item.target.photo.get_formated_photo(enc_format)
-                if formated_photo is not None:
-                    return formated_photo.image 
+                try:
+                    formated_photo = item.target.photo.get_formated_photo(enc_format)
+                    if formated_photo is not None:
+                        return formated_photo.image
+                except Format.DoesNotExist:
+                    pass
             return item.target.photo.image
 
     def get_enclosure_image_attr(self, item, attr):

--- a/tests/unit_project/test_core/test_feeds.py
+++ b/tests/unit_project/test_core/test_feeds.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
+from PIL import Image
+
 from djangosanetesting import DatabaseTestCase
 
 from django.core.urlresolvers import reverse
+from django.http import HttpRequest
 
 from ella.core.models import Listing
+from ella.core.feeds import RSSTopCategoryListings
+from ella.photos.models import Photo, Format
 
 from unit_project.test_core import create_basic_categories, create_and_place_a_publishable, \
         create_and_place_more_publishables, list_all_placements_in_category_by_hour
@@ -21,6 +26,33 @@ class TestFeeds(DatabaseTestCase):
         create_and_place_a_publishable(self)
         create_and_place_more_publishables(self)
         list_all_placements_in_category_by_hour(self)
+        
+        self._feeder = RSSTopCategoryListings('test', HttpRequest())
+
+    def _set_photo(self):
+        from tempfile import mkstemp
+        from django.core.files.base import ContentFile
+        
+        image_file_name = mkstemp(suffix=".jpg", prefix="ella-feeds-tests-")[1]
+        image = Image.new('RGB', (200, 100), "black")
+        image.save(image_file_name, format="jpeg")
+
+        f = open(image_file_name)
+        file = ContentFile(f.read())
+        f.close()
+
+        photo = Photo(
+            title = u"Example 中文 photo",
+            slug = u"example-photo",
+            height = 200,
+            width = 100,
+        )
+
+        photo.image.save("bazaaah", file)
+        photo.save()
+        
+        self.publishable.photo = photo
+        self.publishable.save()
 
     def test_rss(self):
         import feedparser
@@ -46,6 +78,36 @@ class TestFeeds(DatabaseTestCase):
 
         self.assert_equals(len(self.placements), len(d['items']))
 
-
+    def test_get_enclosure_uses_original_when_format_not_set(self):
+        self._set_photo()
+        self.assert_true(self.publishable.photo is not None)
+        original = self.publishable.photo.image
+        new = self._feeder.get_enclosure_image(self.only_publishable, enc_format=None)
+        self.assert_equals(unicode(original), unicode(new))
+    
+    def test_get_enclosure_uses_original_when_format_not_found(self):
+        non_existent_format_name = 'aaa'
+        self._set_photo()
+        self.assert_true(self.publishable.photo is not None)
+        original = self.publishable.photo.image
+        new = self._feeder.get_enclosure_image(self.only_publishable, enc_format=non_existent_format_name)
+        self.assert_equals(unicode(original), unicode(new))
+    
+    def test_get_enclosure_uses_formated_photo_when_format_available(self):
+        existent_format_name = 'enc_format'
+        f = Format.objects.create(name=existent_format_name, max_width=10, max_height=10,
+            flexible_height=False, stretch=False, nocrop=False)
+        f.sites = [self.site_id]
+        
+        self._set_photo()
+        self.assert_true(self.publishable.photo is not None)
+        original = self.publishable.photo.image
+        new = self._feeder.get_enclosure_image(self.only_publishable, enc_format=existent_format_name)
+        self.assert_not_equals(unicode(original), unicode(new))
+    
+    def test_get_enclosure_returns_none_when_no_image_set(self):
+        self.assert_equals(self._feeder.get_enclosure_image(self.only_publishable), None)
+    
+    
 
 


### PR DESCRIPTION
Format can be defined in settings using RSS_ENCLOSURE_PHOTO_FORMAT variable.

If RSS_ENCLOSURE_PHOTO_FORMAT is not set, original photo size will be used.
