### PR TITLE
Related by category are really unique now

### DIFF
--- a/ella/core/related_finders.py
+++ b/ella/core/related_finders.py
@@ -13,7 +13,7 @@ def related_by_category(obj, count, collected_so_far, mods=[], only_from_same_si
     Returns other Publishable objects related to ``obj`` by using the same
     category principle. Returns up to ``count`` objects.
     """
-    related = collected_so_far
+    related = []
     # top objects in given category
     if count > 0:
         from ella.core.models import Listing
@@ -24,7 +24,7 @@ def related_by_category(obj, count, collected_so_far, mods=[], only_from_same_si
         )
         for l in listings[0:count + len(related)]:
             t = l.publishable
-            if t != obj and t not in related:
+            if t != obj and t not in collected_so_far and t not in related:
                 related.append(t)
                 count -= 1
 

--- a/test_ella/test_core/test_related.py
+++ b/test_ella/test_core/test_related.py
@@ -28,7 +28,7 @@ class TestDefaultRelatedFinder(GetRelatedTestCase):
         expected = map(lambda x: x.pk, reversed(self.publishables))
         tools.assert_equals(
                 expected,
-                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected))]
+                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected)*2)]
             )
 
 


### PR DESCRIPTION
This small change should prevent one related Publishable from being displayed twice. (As the results are added each time in `RelatedManager.collect_related`)
