### PR TITLE
2nd try: "can't compare offset-naive and offset-aware datetimes" exception (Django 1.4)

### DIFF
--- a/ella/core/models/publishable.py
+++ b/ella/core/models/publishable.py
@@ -1,4 +1,10 @@
-from datetime import datetime
+try:
+    # try import offset-aware datetime from Django >= 1.4
+    from django.utils.timezone import now as datetime_now
+except ImportError:
+    # backward compatibility with Django < 1.4 (offset-naive datetimes)
+    from datetime import datetime
+    datetime_now = datetime.now
 
 from django.db import models
 from django.conf import settings
@@ -203,7 +209,7 @@ class Publishable(models.Model):
 
     def is_published(self):
         "Return True if the Publishable is currently active."
-        now = datetime.now()
+        now = datetime_now()
         return self.published and now > self.publish_from and \
             (self.publish_to is None or now < self.publish_to)
 


### PR DESCRIPTION
If I try to add some new article in Django admin (http://127.0.0.1:8000/admin/articles/article/add/) and check "Published" in section "Publication" I get "can't compare offset-naive and offset-aware datetimes" exception. I use Django 1.4.

Backward compatibility provided by `datetime.datetime.now()` function.
