### PR TITLE
 Fixed 'Format' object creation with custom id.

### DIFF
--- a/ella/photos/models.py
+++ b/ella/photos/models.py
@@ -251,13 +251,16 @@ class Format(models.Model):
         """Overrides models.Model.save.
 
         - Delete formatted photos if format save and not now created
-          (becouse of possible changes)
+          (because of possible changes)
         """
-
         if self.id:
             for f_photo in self.formatedphoto_set.all():
                 f_photo.delete()
-            kwargs.update({'force_update': True})
+            try:
+                if Format.objects.get(id=self.id):
+                    kwargs.update({'force_update': True})
+            except Format.DoesNotExist:
+                pass
         super(Format, self).save(**kwargs)
 
 


### PR DESCRIPTION
Creating 'Format' object with specified id (not existing) raises "DatabaseError: Forced update did not affect any rows." exception, because force_update is always set to True. 

Code raising exception:

```
from ella.photos.models import Format

f = Format()
f.max_width = 100
f.max_height = 100
f.id = 432
f.save()
```
