### PR TITLE
Modified `source` FK fields to SET_NULL on delete

### DIFF
--- a/ella/core/models/publishable.py
+++ b/ella/core/models/publishable.py
@@ -49,7 +49,7 @@ class Publishable(models.Model):
     # Authors and Sources
     authors = models.ManyToManyField(Author, verbose_name=_('Authors'))
     source = models.ForeignKey(Source, blank=True, null=True,
-        verbose_name=_('Source'))
+        verbose_name=_('Source'), on_delete=models.SET_NULL)
 
     # Main Photo
     photo = CachedForeignKey(Photo, blank=True, null=True, on_delete=models.SET_NULL,

--- a/ella/photos/models.py
+++ b/ella/photos/models.py
@@ -74,7 +74,7 @@ class Photo(models.Model):
 
     # Authors and Sources
     authors = models.ManyToManyField(Author, verbose_name=_('Authors'), related_name='photo_set')
-    source = models.ForeignKey(Source, blank=True, null=True, verbose_name=_('Source'))
+    source = models.ForeignKey(Source, blank=True, null=True, verbose_name=_('Source'), on_delete=models.SET_NULL)
 
     created = models.DateTimeField(auto_now_add=True)
 

--- a/test_ella/test_photos/test_models.py
+++ b/test_ella/test_photos/test_models.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+
+from ella.core.models import Source
+from ella.photos.models import Photo
+
+from ella.utils.test_helpers import create_photo
+
+from nose import tools
+
+class TestPhotoModel(TestCase):
+    " Unit tests for `ella.photos.models.Photo` model. "
+    def setUp(self):
+        super(TestPhotoModel, self).setUp()
+
+        # Make a few simple assertions regarding the state of the test data
+        tools.assert_equals(Source.objects.count(), 0)
+        tools.assert_equals(Photo.objects.count(), 0)
+
+        # Create a Source and Category for the tests
+        self.source_foo = Source.objects.create(name='foo')
+        tools.assert_equals(Source.objects.count(), 1)
+
+    def test_source_is_nulled_on_delete(self):
+        """
+        Assert that the Source field for Photos are
+        set to null (and not deleted) when a `Source` is deleted.
+        """
+        # Create a new Photo and associate it to the `foo` source
+        photo = create_photo(self, source=self.source_foo)
+        tools.assert_equals(Photo.objects.count(), 1)
+
+        # Delete the `source`
+        self.source_foo.delete()
+
+        # Assert that the photo remains, but the `source` field is nulled
+        tools.assert_equals(Photo.objects.count(), 1)
+        tools.assert_equals(Source.objects.count(), 0)
+        photo = Photo.objects.get(id=photo.id)
+        tools.assert_equals(photo.source, None)


### PR DESCRIPTION
Modified `ella.core.models.Publishable` and `ella.photos.models.Photo` 'source' FK fields to SET_NULL on delete (as opposed to deleting the Publishable/Photo when a Source is deleted). 

There are only two `source` foreign keys in the ella codebase and both have been updated in this pull request.

Unit tests accompany these changes.
