### PR TITLE
Fixes for `ella.photos`.

### DIFF
--- a/ella/photos/models.py
+++ b/ella/photos/models.py
@@ -100,6 +100,7 @@ class Photo(models.Model):
 
     def _get_image(self):
         if not hasattr(self, '_pil_image'):
+            self.image.open()
             self._pil_image = Image.open(self.image)
         return self._pil_image
 

--- a/ella/photos/models.py
+++ b/ella/photos/models.py
@@ -258,7 +258,7 @@ class Format(models.Model):
         if self.id:
             for f_photo in self.formatedphoto_set.all():
                 f_photo.delete()
-            kwargs.update({'force_update': True})
+
         super(Format, self).save(**kwargs)
 
 

--- a/ella/photos/models.py
+++ b/ella/photos/models.py
@@ -252,7 +252,7 @@ class Format(models.Model):
         """Overrides models.Model.save.
 
         - Delete formatted photos if format save and not now created
-          (becouse of possible changes)
+          (because of possible changes)
         """
 
         if self.id:


### PR DESCRIPTION
Creating 'Format' object with specified id (not existing) raises "DatabaseError: Forced update did not affect any rows." exception, because force_update is always set to True. 

Code raising exception:

``` python
from ella.photos.models import Format

f = Format()
f.max_width = 100
f.max_height = 100
f.id = 432
f.save()
```

---

Exception "I/O operation on closed file" is raised for photo image. Related issue: http://stackoverflow.com/questions/3029988/django-gives-i-o-operation-on-closed-file-error-when-reading-from-a-saved-imag

Code raising exception: https://github.com/SanomaCZ/ella-hub/blob/master/tests/test_api/test_photos_resources.py#L107-110

``` python
photo = Photo.objects.create(title="photo title", image="path/to/file.jpg")
format = Format.objects.create(name="format_name", max_height=200, max_width=200)
FormatedPhoto.objects.create(photo=photo, format=format)
```
