### PR TITLE
Patching `RedisListingHandler.get_listings()` 

### DIFF
--- a/ella/core/cache/redis.py
+++ b/ella/core/cache/redis.py
@@ -219,7 +219,7 @@ class RedisListingHandler(ListingHandler):
         if min_score or max_score:
             pipe = pipe.zrevrangebyscore(key,
                 max_score, min_score,
-                start=offset, num=offset + count,
+                start=offset, num=count,
                 withscores=True
             )
         else:


### PR DESCRIPTION
Patching `RedisListingHandler.get_listings()`  to pass the correct `count` value to `zrevrangebyscore()`. zrevrangebyscore expects `num` to be the number of results you want it to return - not the "end" value of a slice. Adding unit tests for the changes as well.
