### PR TITLE
fixed related_by_category finder to exclude target obj and fixed url che...

### DIFF
--- a/ella/core/models/publishable.py
+++ b/ella/core/models/publishable.py
@@ -130,7 +130,7 @@ class Publishable(models.Model):
         if not self.category_id or not self.publish_from or not self.slug:
             return
 
-        qset = self.__class__.objects.filter(
+        qset = Publishable.objects.filter(
                 category=self.category,
                 published=True,
                 publish_from__day=self.publish_from.day,
@@ -143,7 +143,7 @@ class Publishable(models.Model):
             qset = qset.exclude(pk=self.pk)
 
         if qset:
-            raise ValidationError(_('Another %s already published at this URL.') % self._meta.verbose_name)
+            raise ValidationError(_('Another %s already published at this URL.') % Publishable._meta.verbose_name)
 
     def save(self, **kwargs):
         # update the content_type if it isn't already set

--- a/ella/core/related_finders.py
+++ b/ella/core/related_finders.py
@@ -16,11 +16,12 @@ def related_by_category(obj, count, collected_so_far, mods=[], only_from_same_si
         cat = obj.category
         listings = Listing.objects.get_queryset_wrapper(
             category=cat,
-            content_types=[ContentType.objects.get_for_model(m) for m in mods]
+            content_types=[ContentType.objects.get_for_model(m) for m in mods],
+            exclude=obj
         )
-        for l in listings[0:count + len(related)]:
+        for l in listings[0:count + len(collected_so_far)]:
             t = l.publishable
-            if t != obj and t not in collected_so_far and t not in related:
+            if t not in collected_so_far and t not in related:
                 related.append(t)
                 count -= 1
 
@@ -42,6 +43,3 @@ def directly_related(obj, count, collected_so_far, mods=[], only_from_same_site=
             ContentType.objects.get_for_model(m).pk for m in mods])
 
     return get_cached_objects(qset.values_list('related_ct', 'related_id')[:count], missing=SKIP)
-
-
-

--- a/ella/core/templatetags/related.py
+++ b/ella/core/templatetags/related.py
@@ -5,6 +5,7 @@ from ella.core.models import Related
 
 register = template.Library()
 
+
 class RelatedNode(template.Node):
     def __init__(self, obj_var, count, var_name, models, finder):
         self.obj_var = obj_var
@@ -22,6 +23,7 @@ class RelatedNode(template.Node):
             mods=self.models, finder=self.finder)
         context[self.var_name] = related
         return ''
+
 
 def parse_related_tag(bits):
     if len(bits) < 6:
@@ -67,13 +69,13 @@ def parse_related_tag(bits):
 @register.tag('related')
 def do_related(parser, token):
     """
-    Get N related models into a context variable optionally specifying a 
+    Get N related models into a context variable optionally specifying a
     named related finder.
 
     **Usage**::
-    
+
         {% related <limit>[ query_type] [app.model, ...] for <object> as <result> %}
-        
+
     **Parameters**::
         ==================================  ================================================
         Option                              Description
@@ -89,13 +91,10 @@ def do_related(parser, token):
         ==================================  ================================================
 
     **Examples**::
-    
+
         {% related 10 for object as related_list %}
         {% related 10 directly articles.article, galleries.gallery for object as related_list %}
     """
     bits = token.split_contents()
     obj_var, count, var_name, mods, finder = parse_related_tag(bits)
     return RelatedNode(obj_var, count, var_name, mods, finder)
-
-
-

--- a/ella/utils/test_helpers.py
+++ b/ella/utils/test_helpers.py
@@ -7,13 +7,14 @@ from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.template.defaultfilters import slugify
 
-from ella.core.models import Category, Publishable
+from ella.core.models import Category, Publishable, Listing
 # choose Article as an example publishable
 from ella.articles.models import Article
 from ella.photos.models import Photo
 from ella.utils.timezone import utc_localize
 
 default_time = utc_localize(datetime(2008, 1, 10))
+
 
 def create_category(title, tree_parent=None, **kwargs):
     defaults = {
@@ -25,6 +26,7 @@ def create_category(title, tree_parent=None, **kwargs):
         tree_parent = Category.objects.get_by_tree_path(tree_parent)
     cat, created = Category.objects.get_or_create(tree_parent=tree_parent, title=title, defaults=defaults)
     return cat
+
 
 def create_basic_categories(case):
     case.site_id = getattr(settings, "SITE_ID", 1)
@@ -48,6 +50,7 @@ def create_basic_categories(case):
     )
     case.addCleanup(Category.objects.clear_cache)
 
+
 def create_and_place_a_publishable(case, **kwargs):
     defaults = dict(
         title=u'First Article',
@@ -62,27 +65,27 @@ def create_and_place_a_publishable(case, **kwargs):
     case.publishable = Article.objects.create(**defaults)
     case.only_publishable = Publishable.objects.get(pk=case.publishable.pk)
 
+
 def create_photo(case, color="black", size=(200, 100), **kwargs):
     # prepare image in temporary directory
     file = StringIO()
     case.image = Image.new('RGB', size, color)
     case.image.save(file, format="jpeg")
 
-
     f = InMemoryUploadedFile(
-            file = file,
-            field_name = 'image',
-            name = 'example-photo.jpg',
-            content_type = 'image/jpeg',
-            size = len(file.getvalue()),
-            charset = None
+            file=file,
+            field_name='image',
+            name='example-photo.jpg',
+            content_type='image/jpeg',
+            size=len(file.getvalue()),
+            charset=None
         )
 
     data = dict(
-        title = u"Example 中文 photo",
-        slug = u"example-photo",
-        height = size[0],
-        width = size[1],
+        title=u"Example 中文 photo",
+        slug=u"example-photo",
+        height=size[0],
+        width=size[1],
     )
     data.update(kwargs)
 
@@ -94,3 +97,12 @@ def create_photo(case, color="black", size=(200, 100), **kwargs):
     case.photo._pil_image = case.image
 
     return case.photo
+
+
+def list_publishable_in_category(case, publishable, category=None, publish_from=None):
+
+    case.listing = Listing.objects.get_or_create(
+        publishable=publishable,
+        category=category or publishable.category,
+        publish_from=publish_from or publishable.publish_from,
+    )[0]

--- a/test_ella/test_app/models.py
+++ b/test_ella/test_app/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from ella.core.models import Publishable
+
+
+class XArticle(Publishable):
+    """
+    ``XArticle`` is extra publishable object for testing.
+    """
+    content = models.TextField(_('Content'), default='')
+
+    class Meta:
+        verbose_name = _('XArticle')
+        verbose_name_plural = _('XArticles')

--- a/test_ella/test_core/__init__.py
+++ b/test_ella/test_core/__init__.py
@@ -7,6 +7,7 @@ from ella.articles.models import Article
 from ella.utils.test_helpers import create_basic_categories, create_and_place_a_publishable, default_time
 from ella.utils import timezone
 
+
 def create_and_place_more_publishables(case):
     """
     Create an article in every category
@@ -24,6 +25,7 @@ def create_and_place_more_publishables(case):
                 content='Some even longer test. \n' * 5
             )
         case.publishables.append(p)
+
 
 def list_all_publishables_in_category_by_hour(case, category=None):
     case.listings = []

--- a/test_ella/test_core/test_related.py
+++ b/test_ella/test_core/test_related.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import timedelta
 from unittest import TestCase as UnitTestCase
 from test_ella.cases import RedisTestCase as TestCase
 
@@ -9,26 +10,34 @@ from ella.core.models import Related, Publishable
 from ella.core.templatetags.related import parse_related_tag
 from ella.photos.models import Photo
 
-from test_ella.test_core import create_basic_categories, create_and_place_a_publishable, \
-        create_and_place_more_publishables, list_all_publishables_in_category_by_hour
+from ella.utils.test_helpers import list_publishable_in_category
+from test_ella.test_core import (
+    create_basic_categories,
+    create_and_place_a_publishable,
+    create_and_place_more_publishables,
+    list_all_publishables_in_category_by_hour,
+    default_time,
+)
+
 
 class GetRelatedTestCase(TestCase):
     def setUp(self):
         super(GetRelatedTestCase, self).setUp()
         create_basic_categories(self)
-        create_and_place_a_publishable(self)
+        create_and_place_a_publishable(self, publish_from=default_time + timedelta(days=1))
         create_and_place_more_publishables(self)
 
         Publishable.objects.all().update(category=self.publishable.category)
 
         list_all_publishables_in_category_by_hour(self, category=self.publishable.category)
 
+
 class TestDefaultRelatedFinder(GetRelatedTestCase):
     def test_returns_unique_objects_or_shorter_list_if_not_available(self):
         expected = map(lambda x: x.pk, reversed(self.publishables))
         tools.assert_equals(
                 expected,
-                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected)*3)]
+                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected) * 3)]
             )
 
     def test_returns_publishables_listed_in_same_cat_if_no_related(self):
@@ -38,6 +47,14 @@ class TestDefaultRelatedFinder(GetRelatedTestCase):
                 [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected))]
             )
 
+    def test_returns_publishables_listed_in_same_cat_if_no_related_and_target_obj_is_listed_too(self):
+        expected = map(lambda x: x.pk, reversed(self.publishables))
+        publish_from = self.publishable.publish_from + timedelta(days=1)
+        list_publishable_in_category(self, self.publishable, publish_from=publish_from)
+        tools.assert_equals(
+                expected,
+                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected))]
+            )
 
     def test_returns_at_most_count_objects(self):
         tools.assert_equals(


### PR DESCRIPTION
fixed related_by_category finder to exclude target obj and fixed url check for non static publishables in clean method of publishable
