### PR TITLE
fixed Publishable url uniqueness by db check in clean metod and fixed category related finder

### DIFF
--- a/ella/core/models/publishable.py
+++ b/ella/core/models/publishable.py
@@ -130,7 +130,9 @@ class Publishable(models.Model):
         if not self.category_id or not self.publish_from or not self.slug:
             return
 
-        qset = self.__class__.objects.filter(
+        # used Publishable instead of self.__class__ becouse we want uniqueness
+        # in Publishale qs not in descendant qs only (for emaple: Article qs)
+        qset = Publishable.objects.filter(
                 category=self.category,
                 published=True,
                 publish_from__day=self.publish_from.day,
@@ -143,7 +145,7 @@ class Publishable(models.Model):
             qset = qset.exclude(pk=self.pk)
 
         if qset:
-            raise ValidationError(_('Another %s already published at this URL.') % self._meta.verbose_name)
+            raise ValidationError(_('Another %s already published at this URL.') % Publishable._meta.verbose_name)
 
     def save(self, **kwargs):
         # update the content_type if it isn't already set

--- a/ella/core/related_finders.py
+++ b/ella/core/related_finders.py
@@ -16,11 +16,12 @@ def related_by_category(obj, count, collected_so_far, mods=[], only_from_same_si
         cat = obj.category
         listings = Listing.objects.get_queryset_wrapper(
             category=cat,
-            content_types=[ContentType.objects.get_for_model(m) for m in mods]
+            content_types=[ContentType.objects.get_for_model(m) for m in mods],
+            exclude=obj
         )
-        for l in listings[0:count + len(related)]:
+        for l in listings[0:count + len(collected_so_far)]:
             t = l.publishable
-            if t != obj and t not in collected_so_far and t not in related:
+            if t not in collected_so_far and t not in related:
                 related.append(t)
                 count -= 1
 

--- a/ella/core/related_finders.py
+++ b/ella/core/related_finders.py
@@ -42,6 +42,3 @@ def directly_related(obj, count, collected_so_far, mods=[], only_from_same_site=
             ContentType.objects.get_for_model(m).pk for m in mods])
 
     return get_cached_objects(qset.values_list('related_ct', 'related_id')[:count], missing=SKIP)
-
-
-

--- a/ella/core/templatetags/related.py
+++ b/ella/core/templatetags/related.py
@@ -5,6 +5,7 @@ from ella.core.models import Related
 
 register = template.Library()
 
+
 class RelatedNode(template.Node):
     def __init__(self, obj_var, count, var_name, models, finder):
         self.obj_var = obj_var
@@ -22,6 +23,7 @@ class RelatedNode(template.Node):
             mods=self.models, finder=self.finder)
         context[self.var_name] = related
         return ''
+
 
 def parse_related_tag(bits):
     if len(bits) < 6:
@@ -67,13 +69,13 @@ def parse_related_tag(bits):
 @register.tag('related')
 def do_related(parser, token):
     """
-    Get N related models into a context variable optionally specifying a 
+    Get N related models into a context variable optionally specifying a
     named related finder.
 
     **Usage**::
-    
+
         {% related <limit>[ query_type] [app.model, ...] for <object> as <result> %}
-        
+
     **Parameters**::
         ==================================  ================================================
         Option                              Description
@@ -89,13 +91,10 @@ def do_related(parser, token):
         ==================================  ================================================
 
     **Examples**::
-    
+
         {% related 10 for object as related_list %}
         {% related 10 directly articles.article, galleries.gallery for object as related_list %}
     """
     bits = token.split_contents()
     obj_var, count, var_name, mods, finder = parse_related_tag(bits)
     return RelatedNode(obj_var, count, var_name, mods, finder)
-
-
-

--- a/ella/utils/test_helpers.py
+++ b/ella/utils/test_helpers.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.template.defaultfilters import slugify
 
-from ella.core.models import Category, Publishable
+from ella.core.models import Category, Publishable, Listing
 # choose Article as an example publishable
 from ella.articles.models import Article
 from ella.photos.models import Photo
@@ -97,3 +97,12 @@ def create_photo(case, color="black", size=(200, 100), **kwargs):
     case.photo._pil_image = case.image
 
     return case.photo
+
+
+def list_publishable_in_category(case, publishable, category=None, publish_from=None):
+
+    case.listing = Listing.objects.get_or_create(
+        publishable=publishable,
+        category=category or publishable.category,
+        publish_from=publish_from or publishable.publish_from,
+    )[0]

--- a/ella/utils/test_helpers.py
+++ b/ella/utils/test_helpers.py
@@ -15,6 +15,7 @@ from ella.utils.timezone import utc_localize
 
 default_time = utc_localize(datetime(2008, 1, 10))
 
+
 def create_category(title, tree_parent=None, **kwargs):
     defaults = {
         'site_id': getattr(settings, "SITE_ID", 1),
@@ -25,6 +26,7 @@ def create_category(title, tree_parent=None, **kwargs):
         tree_parent = Category.objects.get_by_tree_path(tree_parent)
     cat, created = Category.objects.get_or_create(tree_parent=tree_parent, title=title, defaults=defaults)
     return cat
+
 
 def create_basic_categories(case):
     case.site_id = getattr(settings, "SITE_ID", 1)
@@ -48,6 +50,7 @@ def create_basic_categories(case):
     )
     case.addCleanup(Category.objects.clear_cache)
 
+
 def create_and_place_a_publishable(case, **kwargs):
     defaults = dict(
         title=u'First Article',
@@ -62,27 +65,27 @@ def create_and_place_a_publishable(case, **kwargs):
     case.publishable = Article.objects.create(**defaults)
     case.only_publishable = Publishable.objects.get(pk=case.publishable.pk)
 
+
 def create_photo(case, color="black", size=(200, 100), **kwargs):
     # prepare image in temporary directory
     file = StringIO()
     case.image = Image.new('RGB', size, color)
     case.image.save(file, format="jpeg")
 
-
     f = InMemoryUploadedFile(
-            file = file,
-            field_name = 'image',
-            name = 'example-photo.jpg',
-            content_type = 'image/jpeg',
-            size = len(file.getvalue()),
-            charset = None
+            file=file,
+            field_name='image',
+            name='example-photo.jpg',
+            content_type='image/jpeg',
+            size=len(file.getvalue()),
+            charset=None
         )
 
     data = dict(
-        title = u"Example 中文 photo",
-        slug = u"example-photo",
-        height = size[0],
-        width = size[1],
+        title=u"Example 中文 photo",
+        slug=u"example-photo",
+        height=size[0],
+        width=size[1],
     )
     data.update(kwargs)
 

--- a/test_ella/cases.py
+++ b/test_ella/cases.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from ella.core.cache.redis import client
 
+
 class RedisTestCase(TestCase):
     def tearDown(self):
         super(RedisTestCase, self).tearDown()

--- a/test_ella/test_app/models.py
+++ b/test_ella/test_app/models.py
@@ -1,0 +1,17 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from ella.core.models import Publishable
+
+
+class XArticle(Publishable):
+    """
+    ``XArticle`` is extra publishable descendant for testing.
+    Is used for possibility testing descendants of publishable
+    with different content type
+    """
+    content = models.TextField(_('Content'), default='')
+
+    class Meta:
+        verbose_name = _('XArticle')
+        verbose_name_plural = _('XArticles')

--- a/test_ella/test_core/__init__.py
+++ b/test_ella/test_core/__init__.py
@@ -7,6 +7,7 @@ from ella.articles.models import Article
 from ella.utils.test_helpers import create_basic_categories, create_and_place_a_publishable, default_time
 from ella.utils import timezone
 
+
 def create_and_place_more_publishables(case):
     """
     Create an article in every category
@@ -25,6 +26,7 @@ def create_and_place_more_publishables(case):
             )
         case.publishables.append(p)
 
+
 def list_all_publishables_in_category_by_hour(case, category=None):
     case.listings = []
 
@@ -40,4 +42,3 @@ def list_all_publishables_in_category_by_hour(case, category=None):
         )
         publish_from += timedelta(seconds=3600)
     case.listings.reverse()
-

--- a/test_ella/test_core/test_publishable.py
+++ b/test_ella/test_core/test_publishable.py
@@ -17,11 +17,13 @@ from nose import tools, SkipTest
 
 from test_ella.test_core import create_basic_categories, create_and_place_a_publishable, default_time
 
+
 class PublishableTestCase(TestCase):
     def setUp(self):
         super(PublishableTestCase, self).setUp()
         create_basic_categories(self)
         create_and_place_a_publishable(self)
+
 
 class TestLastUpdated(PublishableTestCase):
     def test_last_updated_moved_if_default(self):
@@ -36,6 +38,7 @@ class TestLastUpdated(PublishableTestCase):
         self.publishable.publish_from = now
         self.publishable.save(force_update=True)
         tools.assert_equals(now + timedelta(days=1), self.publishable.last_updated)
+
 
 class TestPublishableHelpers(PublishableTestCase):
     def test_url(self):
@@ -56,7 +59,7 @@ class TestPublishableHelpers(PublishableTestCase):
         self.publishable.app_data['core'] = 'testing'
         self.publishable.save()
 
-        p = self.publishable.content_type.get_object_for_this_type(pk=self.publishable.pk)
+        self.publishable.content_type.get_object_for_this_type(pk=self.publishable.pk)
         tools.assert_equals({'core': 'testing'}, self.publishable.app_data)
 
     def test_saving_base_publishable_does_not_update_content_type(self):
@@ -201,4 +204,3 @@ class TestSignals(TestCase):
         tools.assert_equals(1, len(self.publish_received))
         tools.assert_equals(0, len(self.unpublish_received))
         tools.assert_equals(self.publishable, self.publish_received[0]['publishable'].target)
-

--- a/test_ella/test_core/test_publishable.py
+++ b/test_ella/test_core/test_publishable.py
@@ -16,6 +16,7 @@ from ella.utils import timezone
 from nose import tools, SkipTest
 
 from test_ella.test_core import create_basic_categories, create_and_place_a_publishable, default_time
+from test_ella.test_app.models import XArticle
 
 
 class PublishableTestCase(TestCase):
@@ -134,6 +135,24 @@ class TestUrl(PublishableTestCase):
     def test_unique_url_validation(self):
         self.publishable.pk = None
         tools.assert_raises(ValidationError, self.publishable.full_clean)
+
+    def test_unique_url_validation_for_non_static_objects_with_different_content_types(self):
+        publishable = self.publishable
+        if publishable.static:
+            publishable.static = False
+            publishable.save()
+
+        xarticle = XArticle(
+            title=self.publishable.title,
+            slug=self.publishable.slug,
+            description=self.publishable.description,
+            category=self.publishable.category,
+            publish_from=self.publishable.publish_from,
+            published=True,
+            static=False,
+            content=self.publishable.content
+        )
+        tools.assert_raises(ValidationError, xarticle.full_clean)
 
     def test_url_is_tested_for_published_objects_only(self):
         self.publishable.pk = None

--- a/test_ella/test_core/test_related.py
+++ b/test_ella/test_core/test_related.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import timedelta
 from unittest import TestCase as UnitTestCase
 from test_ella.cases import RedisTestCase as TestCase
 
@@ -9,8 +10,13 @@ from ella.core.models import Related, Publishable
 from ella.core.templatetags.related import parse_related_tag
 from ella.photos.models import Photo
 
-from test_ella.test_core import create_basic_categories, create_and_place_a_publishable, \
-        create_and_place_more_publishables, list_all_publishables_in_category_by_hour
+from ella.utils.test_helpers import list_publishable_in_category
+from test_ella.test_core import (
+    create_basic_categories,
+    create_and_place_a_publishable,
+    create_and_place_more_publishables,
+    list_all_publishables_in_category_by_hour,
+)
 
 
 class GetRelatedTestCase(TestCase):
@@ -35,6 +41,15 @@ class TestDefaultRelatedFinder(GetRelatedTestCase):
 
     def test_returns_publishables_listed_in_same_cat_if_no_related(self):
         expected = map(lambda x: x.pk, reversed(self.publishables))
+        tools.assert_equals(
+                expected,
+                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected))]
+            )
+
+    def test_returns_publishables_listed_in_same_cat_if_no_related_and_target_obj_is_listed_too(self):
+        expected = map(lambda x: x.pk, reversed(self.publishables))
+        youngest_publish_from = self.publishables[-1].publish_from + timedelta(days=1)
+        list_publishable_in_category(self, self.publishable, publish_from=youngest_publish_from)
         tools.assert_equals(
                 expected,
                 [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected))]

--- a/test_ella/test_core/test_related.py
+++ b/test_ella/test_core/test_related.py
@@ -12,6 +12,7 @@ from ella.photos.models import Photo
 from test_ella.test_core import create_basic_categories, create_and_place_a_publishable, \
         create_and_place_more_publishables, list_all_publishables_in_category_by_hour
 
+
 class GetRelatedTestCase(TestCase):
     def setUp(self):
         super(GetRelatedTestCase, self).setUp()
@@ -23,12 +24,13 @@ class GetRelatedTestCase(TestCase):
 
         list_all_publishables_in_category_by_hour(self, category=self.publishable.category)
 
+
 class TestDefaultRelatedFinder(GetRelatedTestCase):
     def test_returns_unique_objects_or_shorter_list_if_not_available(self):
         expected = map(lambda x: x.pk, reversed(self.publishables))
         tools.assert_equals(
                 expected,
-                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected)*3)]
+                [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected) * 3)]
             )
 
     def test_returns_publishables_listed_in_same_cat_if_no_related(self):
@@ -37,7 +39,6 @@ class TestDefaultRelatedFinder(GetRelatedTestCase):
                 expected,
                 [p.pk for p in Related.objects.get_related_for_object(self.publishable, len(expected))]
             )
-
 
     def test_returns_at_most_count_objects(self):
         tools.assert_equals(
@@ -158,4 +159,3 @@ class TestRelatedTagParser(UnitTestCase):
         tools.assert_equals('some_var', var_name)
         tools.assert_equals([Article, Photo], mods)
         tools.assert_equals("directly", finder)
-


### PR DESCRIPTION
There are three commits:

First is only PEP8 fixes.

Second  is for category related finder. Example in current version of ella: I have publishble x and x has set category y and is also listed in this category and I want 4 related objects by category and finder gives me only 3 objects although there is many objects (This situation happens only if position of x in listing query set is less than count specification).

Last is for Publishable clean method where is check of uniqueness by category, slug, publish_from for non static objects. There is replaced self.**class** with Publishable, becouse self.**class** validate uniqueness for specific content type (for example only in articles query set) and not in Publishable qs and it breaks unique url per publishable.
