### PR TITLE
Make tests pass with PYTHONHASHSEED=random

### DIFF
--- a/test_ella/test_core/test_templatetags.py
+++ b/test_ella/test_core/test_templatetags.py
@@ -41,14 +41,25 @@ class TestPaginate(UnitTestCase):
             'page': page
         }
 
-        tools.assert_equals((('inclusion_tags/paginator.html', 'inc/paginator.html'), {
+        tname, context = _do_paginator(context, 2, None)
+
+        tools.assert_equals(
+            ('inclusion_tags/paginator.html', 'inc/paginator.html'),
+            tname,
+        )
+
+        query_params = context.pop('query_params')
+        tools.assert_equals({
             'page': page,
             'page_numbers': [1, 2, 3, 4, 5],
-            'query_params': '?using=custom_lh&other=param+with+spaces&p=',
             'results_per_page': 10,
             'show_first': False,
             'show_last': True
-        }), _do_paginator(context, 2, None))
+        }, context)
+        tools.assert_in(query_params, (
+            '?using=custom_lh&other=param+with+spaces&p=',
+            '?other=param+with+spaces&using=custom_lh&p=',
+        ))
 
     def test_always_include_given_number_of_pages(self):
         page = Paginator(range(100), 9).page(1)
@@ -221,7 +232,10 @@ class TestBoxTag(UnitTestCase):
                 level: 2
                 some_other_param: xxx
             {% endbox %}''')
-        tools.assert_equals('some_other_param:xxx|level:2|', t.render(template.Context()))
+        tools.assert_in(t.render(template.Context()), (
+                'some_other_param:xxx|level:2|',
+                'level:2|some_other_param:xxx|',
+            ))
 
     def test_box_wirks_with_variable_instead_of_lookup(self):
         site = Site.objects.get(pk=1)

--- a/test_ella/test_photos/test_photo.py
+++ b/test_ella/test_photos/test_photo.py
@@ -95,7 +95,7 @@ class TestPhoto(TestCase):
                 'url': '/static/photos/2012/02/14/1-1-example-photo_12.jpg',
             }
             actual = redis.hgetall(REDIS_FORMATTED_PHOTO_KEY % (self.photo.id, self.basic_format.id))
-            tools.assert_equals(expected.keys(), actual.keys())
+            tools.assert_equals(set(expected.keys()), set(actual.keys()))
             tools.assert_equals(expected['width'], actual['width'])
             tools.assert_equals(expected['height'], actual['height'])
 


### PR DESCRIPTION
Hello! I believe this is my first patch for a Django-based project, hopefully I'm doing everything right.
I installed the code and ran the tests, but found some failures due to my environment. 

```
Due to CVE-2012-1150, CPython now allows using a random seed for hashes,
so set/dict order is no longer predictable.

Update tests to pass even if the hash seed is randomized.
Add a testing-only argument to ella.core.templatetags.pagination._do_paginator
to sort query params before encoding them.
```

In `test_templatetags.test_params_are_parsed`, I didn't find a good way for to sort a dictionary given to a `for` in a Django template.
